### PR TITLE
Update contributors.txt

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -280,3 +280,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/10/20, adamwojs, Adam Wójs, adam[at]wojs.pl
 2020/10/24, cliid, Jiwu Jang, jiwujang@naver.com
 2020/11/05, MichelHartmann, Michel Hartmann, MichelHartmann@users.noreply.github.com
+2020/12/01, maxence-lefebvre, Maxence Lefebvre, maxence-lefebvre@users.noreply.github.com


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->